### PR TITLE
Add Travis CI for automated testing of pull requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+sudo: false
+dist: trusty
+language: python
+python:
+    - "2.7.13"
+    - "3.6.1"
+    - "nightly"  # currently points to 3.7-dev
+install:
+    - pip install flake8
+before_script:
+    # stop the build if there are Python syntax errors
+    - flake8 . --count --select=E901,E999 --statistics
+    # exit-zero treates all errors as warnings.  The GitHub editor is 127 chars wide
+    - flake8 . --count --exit-zero --max-line-length=127 --statistics
+script: true
+    # python test/test_IBMQuantumExperience.py  # I am yet not sure how to make this work.
+notifications:
+    on_success: change
+    on_failure: always


### PR DESCRIPTION
This will automatically run flake8 tests and the unittest on every pull request to this repo. This will help contributors know if their submissions would break the build. To turn on this free service, you would need to do steps 1 and 2 of https://docs.travis-ci.com/user/getting-started/